### PR TITLE
Mark inline JS blocks as an embeddedLanguage

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
             {
                 "language": "pegjs",
                 "scopeName": "source.pegjs",
-                "path": "./syntaxes/pegjs.json"
+                "path": "./syntaxes/pegjs.json",
+                "embeddedLanguages": {
+                    "meta.embedded.block.javascript": "javascript"
+                }
             }
         ],
         "snippets": [

--- a/syntaxes/pegjs.json
+++ b/syntaxes/pegjs.json
@@ -109,7 +109,7 @@
         "inlinejs": {
             "begin": "{",
             "end": "}",
-            "name": "source.js.embedded.pegjs",
+            "name": "meta.embedded.block.javascript",
             "patterns": [
                 {
                     "include": "source.js"


### PR DESCRIPTION
Apologies for not creating an issue first, I'd already implemented the fix before reading the CONTRIBUTING.md so figured I might as well PR it right away :)

This change marks inline JS blocks as an `embeddedLanguage`, so that bracket matching, user snippets etc. work correctly in addition to the syntax highlighting, [as per the documentation](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#embedded-languages).

It also changes the scope name for such blocks, as the documentation recommends doing so:

> To override this behavior, you can use a `meta.embedded.*` scope to reset VS Code's marking of tokens as string or comment content. It is a good idea to always wrap embedded language in a `meta.embedded.*` scope to make sure VS Code treats the embedded language properly.

This may count as a breaking change for people who previously had custom styling specific to the `source.js.embedded.pegjs` scope, but I doubt that this is common (or that anyone has done so at all, really).