### PR TITLE
Switch to peggy, and add support for @ operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,13 @@
                 "aliases": [
                     "PEG.js",
                     "pegjs",
-                    "peg.js"
+                    "peg.js",
+                    "Peggy",
+                    "peggy"
                 ],
                 "extensions": [
-                    ".pegjs"
+                    ".pegjs",
+                    ".peggy"
                 ],
                 "configuration": "./pegjs.configuration.json"
             }
@@ -73,7 +76,7 @@
         "@types/node": "12.12.2"
     },
     "dependencies": {
-        "pegjs": "^0.10.0",
+        "peggy": "^1.1.0",
         "vscode-languageserver": "^6.1.1",
         "vscode-languageserver-textdocument": "^1.0.1",
         "vscode-languageclient": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -70,15 +70,14 @@
         "watch": "tsc -b -w"
     },
     "devDependencies": {
-        "typescript": "^4.0.3",
-        "@types/pegjs": "^0.10.2",
+        "@types/node": "12.12.2",
         "@types/vscode": "^1.50.0",
-        "@types/node": "12.12.2"
+        "typescript": "^4.0.3"
     },
     "dependencies": {
         "peggy": "^1.1.0",
+        "vscode-languageclient": "^6.1.3",
         "vscode-languageserver": "^6.1.1",
-        "vscode-languageserver-textdocument": "^1.0.1",
-        "vscode-languageclient": "^6.1.3"
+        "vscode-languageserver-textdocument": "^1.0.1"
     }
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as PEG from 'pegjs';
+import * as PEG from 'peggy';
 import {
     createConnection,
     Diagnostic,

--- a/syntaxes/pegjs.json
+++ b/syntaxes/pegjs.json
@@ -103,7 +103,7 @@
             }
         },
         "operators": {
-            "match": "[*?/.$!=+&]",
+            "match": "[*?/.$!=+&@]",
             "name": "keyword.operator.pegjs"
         },
         "inlinejs": {


### PR DESCRIPTION
Hi there!  We've moved development on pegjs to a community fork called "[Peggy](https://github.com/peggyjs/peggy)".  I use your extension all the time, and wonder if you might be willing to move to peggy to support some of the new features that we just [released](https://github.com/peggyjs/peggy/releases/tag/v1.1.0).

This is a minimal patch that does `s/pegjs/peggy/g` and adds support for our new `@` operator.